### PR TITLE
Fix #2 - Shelly now only inserts the response as text if the content …

### DIFF
--- a/public/src/config.js.dist
+++ b/public/src/config.js.dist
@@ -25,6 +25,7 @@ var CONFIG = CONFIG || (function () {
     message += " %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% \n";
 
     return {
+        "debug": false,
         "MOTD": message,
         "user": {
             "name": "guest",


### PR DESCRIPTION
…type header doesn't include html and inserts the response as HTML otherwise;

Fix #4 - The initial function doesn't need to be async;

Feature: You can now provide a JS function to process the response;

BREAKING CHANGE: If a function is not provided, Shelly considers that the response will be JSON with a 'response' attribute, meaning it now deals with `data.response`;

Feature: You can now configure Shelly as in 'debug mode' so it throws the response object to a console table.